### PR TITLE
`pick` should return tree instead of path

### DIFF
--- a/Diagrams/Actions.elm
+++ b/Diagrams/Actions.elm
@@ -68,5 +68,6 @@ last l = case l of
            [x] -> x
            (x::xs) -> last xs
 
+-- TODO: maybe mousePosAtTag : MouseEvent t a -> t -> Point
 collageMousePos : MouseEvent t a -> Point
 collageMousePos (MouseEvent evt) = (last evt.path).offset

--- a/Diagrams/Actions.elm
+++ b/Diagrams/Actions.elm
@@ -17,14 +17,23 @@ import Diagrams.Geom (..)
 -- TODO: odd place for these to live
 {-| (Tag, Coordinates) pairs from bottom of tree to top; result of
 calling `pick` (see below). -}
-type alias PickPath t a = List (PickPathElem t a)
-type alias PickPathElem t a = { tag : t
-                              , actionSet : ActionSet t a
-                              , offset : Point
-                              }
-type MouseEvent t a = MouseEvent { offset : Point
-                                 , pickPath : PickPath t a
-                                 }
+type PickTree t a
+    = PickTag { tag : t
+              , offset : Point
+              , actionSet : ActionSet t a
+              , child : PickTree t a
+              }
+    | PickLayers (List (PickTree t a))
+    | PickLeaf
+
+
+type alias PickPath t a = List (PickedTag t a)
+type alias PickedTag t a = { actionSet : ActionSet t a
+                           , offset : Point
+                           , tag : t
+                           }
+
+type MouseEvent t a = MouseEvent { offset : Point } -- TODO: path
 
 {-| Given an event, return (a) an action resulting from that event, and (b) whether to stop this
 mouse event from "bubbling up" to handlers higher up the tree. -}
@@ -61,5 +70,5 @@ last l = case l of
            [x] -> x
            (x::xs) -> last xs
 
-collageMousePos : MouseEvent t a -> Point
-collageMousePos (MouseEvent evt) = (last evt.pickPath).offset
+--collageMousePos : MouseEvent t a -> Point
+--collageMousePos (MouseEvent evt) = (last evt.pickTree).offset

--- a/Diagrams/Actions.elm
+++ b/Diagrams/Actions.elm
@@ -29,6 +29,9 @@ type PickTree t a
 type alias PickPath t = List (PickPathElem t)
 type alias PickPathElem t = { tag : t, offset : Point }
 
+{-| Path: list of (tag, offset) from bottom of tree to top.
+Offset: offset at lowest level in tree. -}
+-- TODO: a type variable not needed
 type MouseEvent t a = MouseEvent { offset : Point
                                  , path : PickPath t
                                  }
@@ -68,6 +71,15 @@ last l = case l of
            [x] -> x
            (x::xs) -> last xs
 
--- TODO: maybe mousePosAtTag : MouseEvent t a -> t -> Point
-collageMousePos : MouseEvent t a -> Point
-collageMousePos (MouseEvent evt) = (last evt.path).offset
+mousePosAtPath : MouseEvent t a -> List t -> Maybe Point
+mousePosAtPath (MouseEvent evt) tagPath =
+    let a = Debug.log "pp, tp" (evt.path, tagPath)
+        recurse : PickPath t -> List t -> Maybe Point
+        recurse pp tp =
+          case (pp, tp) of
+            ({tag, offset}::evtTags, [wantedTag]) ->
+                if tag == wantedTag then Just offset else Nothing
+            ({tag, offset}::evtTags, wantedTag::tags) ->
+                if tag == wantedTag then recurse evtTags tags else Nothing
+            _ -> Nothing
+    in recurse (L.reverse evt.path) tagPath

--- a/Diagrams/Actions.elm
+++ b/Diagrams/Actions.elm
@@ -18,22 +18,20 @@ import Diagrams.Geom (..)
 {-| (Tag, Coordinates) pairs from bottom of tree to top; result of
 calling `pick` (see below). -}
 type PickTree t a
-    = PickTag { tag : t
+    = PickLayers (List (PickTree t a))
+    | PickLeaf
+    | PickTag { tag : t
               , offset : Point
               , actionSet : ActionSet t a
               , child : PickTree t a
               }
-    | PickLayers (List (PickTree t a))
-    | PickLeaf
 
+type alias PickPath t = List (PickPathElem t)
+type alias PickPathElem t = { tag : t, offset : Point }
 
-type alias PickPath t a = List (PickedTag t a)
-type alias PickedTag t a = { actionSet : ActionSet t a
-                           , offset : Point
-                           , tag : t
-                           }
-
-type MouseEvent t a = MouseEvent { offset : Point } -- TODO: path
+type MouseEvent t a = MouseEvent { offset : Point
+                                 , path : PickPath t
+                                 }
 
 {-| Given an event, return (a) an action resulting from that event, and (b) whether to stop this
 mouse event from "bubbling up" to handlers higher up the tree. -}
@@ -70,5 +68,5 @@ last l = case l of
            [x] -> x
            (x::xs) -> last xs
 
---collageMousePos : MouseEvent t a -> Point
---collageMousePos (MouseEvent evt) = (last evt.pickTree).offset
+collageMousePos : MouseEvent t a -> Point
+collageMousePos (MouseEvent evt) = (last evt.path).offset

--- a/Diagrams/Geom.elm
+++ b/Diagrams/Geom.elm
@@ -8,6 +8,8 @@ module Diagrams.Geom where
 @docs BBox, OffsetDimsBox, Dims, bbox2offsetDims
 -}
 
+import Debug
+
 type alias Point = (Float, Float)
 
 type Transform
@@ -28,10 +30,11 @@ magnitude : Point -> Float
 magnitude (x, y) = sqrt <| (x^2) + (y^2)
 
 invertTrans : Transform -> Transform
-invertTrans t = case t of
-                  Rotate angle -> Rotate (-angle)
-                  Scale factor -> Scale (1/factor)
-                  Translate x y -> Translate (-x) (-y)        
+invertTrans t =
+    case t of
+      Rotate angle -> Rotate (-angle)
+      Scale factor -> Scale (1/factor)
+      Translate x y -> Translate (-x) (-y)
 
 -- linear interpolation
 {-| linear interpolation. To map x from interval (imin, imax) to (omin, omax), use:
@@ -43,8 +46,19 @@ lerp : (Float, Float) -> (Float, Float) -> Float -> Float
 lerp (omin, omax) (imin, imax) input = omin + (omax - omin) * (input - imin) / (imax - imin)
 
 type alias BBox = { up : Float, down : Float, left : Float, right : Float }
+-- offset is the middle of the box
 type alias OffsetDimsBox = { offset : (Float, Float), dims : Dims } -- TODO: translate is a vector (?)
 type alias Dims = { width : Float, height : Float }
+
+pointInside : Point -> OffsetDimsBox -> Bool
+pointInside (x, y) {offset, dims} =
+  let (ox, oy) = offset
+      halfWidth = dims.width/2
+      halfHeight = dims.height/2
+      d = Debug.log "pi" ((x,y), {offset=offset, dims=dims}, (x >= ox - halfWidth && x <= ox + halfWidth) &&
+        (y >= oy - halfHeight && y <= oy + halfHeight))
+  in (x >= ox - halfWidth && x <= ox + halfWidth) &&
+        (y >= oy - halfHeight && y <= oy + halfHeight)
 
 bbox2offsetDims : BBox -> OffsetDimsBox
 bbox2offsetDims bbox = { offset = ((bbox.right - bbox.left)/2, (bbox.up - bbox.down)/2)

--- a/Diagrams/Interact.elm
+++ b/Diagrams/Interact.elm
@@ -72,7 +72,7 @@ makeFoldUpdate updateF renderF =
             newDiagram = renderF newModel
         in { mouseState = newMS
            , diagram = newDiagram
-           , modelState = Debug.watch "State" newModel
+           , modelState = newModel
            }
 
 initInteractState : RenderFunc m t a -> m -> InteractionState m t a
@@ -89,7 +89,7 @@ initInteractState render model =
 new `MouseDiagram` with list of actions triggered by this mouse event. -}
 processMouseEvent : Diagram t a -> MouseState t a -> PrimMouseEvent -> (MouseState t a, List a)
 processMouseEvent diagram mouseState (evt, mousePos) =
-    let overTree = pick diagram mousePos -- need to pick every time because actions may have changed
+    let overTree = Debug.watch "OT" <| pick diagram mousePos -- need to pick every time because actions may have changed
         overPickedTags = preorderTraverse overTree
         overPaths = tagPaths overPickedTags
         oldOverPickedTags = mouseState.overPickedTags

--- a/Diagrams/Query.elm
+++ b/Diagrams/Query.elm
@@ -2,7 +2,7 @@ module Diagrams.Query where
 
 {-| Retreive information about laid-out diagrams.
 
-@docs pick, TagPath, getCoords
+@docs pick, getCoords
 -}
 
 import List as L
@@ -15,6 +15,7 @@ import Diagrams.Geom (..)
 import Diagrams.Actions (..)
 import Diagrams.FillStroke (..)
 
+-- TODO: new docs
 {-| Given a Diagram t and a point (e.g. of the mouse), return the list of Tag nodes between
 the diagram root and the leaf node the point is within (a primitive visual element), along
 with the point's offset from the local origin at each level. If the mouse is not over a leaf

--- a/Diagrams/Query.elm
+++ b/Diagrams/Query.elm
@@ -51,10 +51,10 @@ pick diag point =
                           xs -> Just <| PickLayers xs
          Tag t acts diagram -> 
             pick diagram point |> M.map (\res -> PickTag { tag = t
-                                                        , actionSet = acts
-                                                        , offset = point
-                                                        , child = res
-                                                        })
+                                                         , actionSet = acts
+                                                         , offset = point
+                                                         , child = res
+                                                         })
          TransformD trans diagram -> pick diagram (applyTrans (invertTrans trans) point)
 
 -- like M.oneOf, for lists...

--- a/examples/Basic.elm
+++ b/examples/Basic.elm
@@ -35,17 +35,18 @@ type Action = ClickCirc Point
 
 defLine = C.defaultLine
 
+testDia : Diagram Tag Action
 testDia = let aPath = path [(-50,-50), (30, 100)] C.defaultLine
               rectOrange = tagWithActions RectOrange
-                              { emptyActionSet | mouseEnter <- Just EnterOrange
-                                               , mouseLeave <- Just LeaveOrange }
+                              { emptyActionSet | mouseEnter <- Just <| keepBubbling <| (\(MouseEvent evt) -> EnterOrange evt.offset)
+                                               , mouseLeave <- Just <| keepBubbling <| (\(MouseEvent evt) -> LeaveOrange evt.offset) }
                               <| rect 50 70 (fillAndStroke (C.Solid Color.orange) { defLine | width <- 20, cap <- C.Padded })
               rectBlue = tagWithActions RectBlue
-                              { emptyActionSet | mouseMove <- Just MoveBlue }
+                              { emptyActionSet | mouseMove <- Just <| keepBubbling <| (\(MouseEvent evt) -> MoveBlue evt.offset) }
                               <| rect 70 50 (justSolidFill Color.blue)
               rects = vcat [ rectOrange , rectBlue ]
               circ = tagWithActions Circ
-                            { emptyActionSet | click <- Just ClickCirc }
+                            { emptyActionSet | click <- Just <| keepBubbling <| (\(MouseEvent evt) -> ClickCirc evt.offset) }
                             <| circle 20 (fillAndStroke (C.Solid Color.yellow) { defLine | width <- 2, cap <- C.Padded })
               justText = text "Foo" (let ds = T.defaultStyle in {ds | bold <- True})
               someText = tag Textt <| background (justSolidFill Color.lightBlue) <| pad 5 <| justText
@@ -65,6 +66,6 @@ initModel : Model
 initModel = ()
 
 diagrams : Signal (Diagram Tag Action)
-diagrams = interactFold updateF renderF fullWindowCollageLoc initModel
+diagrams = interactFold updateF renderF fullWindowCollageLocFunc initModel
 
 main = Signal.map2 fullWindowView Window.dimensions diagrams


### PR DESCRIPTION
...because when the mouse is over two or more diagrams that are occluding each other, it should let you know that the mouse is over both — this is represented by a fork in the tree.
