### PR TITLE
fix getCoords bug

### DIFF
--- a/examples/GetCoordsTest.elm
+++ b/examples/GetCoordsTest.elm
@@ -1,0 +1,25 @@
+module GetCoordsTest where
+
+import Color
+import Debug
+import Diagrams.Core exposing (..)
+import Diagrams.Align exposing (..)
+import Diagrams.FillStroke exposing (..)
+import Diagrams.Query exposing (..)
+import Diagrams.FullWindow exposing (..)
+import Signal
+import Window
+
+type BoxTag = OuterBox | InnerBox
+
+innerBox = (tag InnerBox <| rect 60 30 (justFill <| Solid Color.blue)) |> rotate 30 |> move (-50,60)
+outerBox = tag OuterBox <| rect 100 120 (justFill <| Solid Color.yellow)
+
+test : Diagram BoxTag a
+test =
+    let dia = innerBox `atop` outerBox
+        dummy = Debug.log "coords" <| getCoords dia [InnerBox]
+    in dia
+
+main = fullWindowMain test
+


### PR DESCRIPTION
looking into #29. Problem seems to be that `Geom.applyTrans` doesn't keep the context of transformations above it the way that the canvas does when the Diagram is being rendered — probably need to use some kind of stack in getCoords. (Can use Transform2D lib to combine transformations.)
